### PR TITLE
Fix local mod support on Linux

### DIFF
--- a/bt_mod_loader_installer/mods/mods_scene_local.gd
+++ b/bt_mod_loader_installer/mods/mods_scene_local.gd
@@ -88,7 +88,9 @@ func add_mod_to_list(mod, getContainer, fromDatabase :bool= false):
 	print("Added mod to list:", mod.get("name_pretty", "Unknown"))
 
 func _on_file_dialog_dir_selected(dir: String) -> void:
-	var destination :String= Manager.main.path + "\\mods-unpacked"
+	var destination: String = Manager.main.path + "/mods-unpacked"
+	if OS.get_name() == "Windows":
+		destination = Manager.main.path + "\\mods-unpacked"
 	
 	var dest :DirAccess= DirAccess.open(destination)
 	


### PR DESCRIPTION
Previously bloodthief-mod-loader would crash when attempting to open a local mod on Linux. 
![image](https://github.com/user-attachments/assets/aca1397f-91ac-49a3-b59f-50f1a590b0b5)
This PR fixes the use of the backwards slash on all UNIX based operating systems.